### PR TITLE
Update OverlapSettings.cs

### DIFF
--- a/OverlapSugar/OverlapSettings.cs
+++ b/OverlapSugar/OverlapSettings.cs
@@ -162,7 +162,7 @@ namespace NTC.OverlapSugar
             
             if (_overlapPoint == null)
                 return false;
-            
+#if UNITY_EDITOR            
             Gizmos.matrix = _overlapPoint.localToWorldMatrix;
             Gizmos.color = _gizmosColor;
 
@@ -172,7 +172,7 @@ namespace NTC.OverlapSugar
                 case OverlapType.Sphere: Gizmos.DrawSphere(_positionOffset, _sphereRadius); break;
                 default: throw new ArgumentOutOfRangeException(nameof(_overlapType));
             }
-
+##endif
             return true;
         }
     }


### PR DESCRIPTION
To strip down Gizmo Related logic as it won't be running in game and would just be calling dummy code by unity at runtime.

You should also remove the draw gizmo *bool* and *Color* from this variable and implement it via some attribute. As having those reference in variable would increase memory footprint. Or Pass it on, call for TryDrawGizmos.

I love this asset BTW, Sir.